### PR TITLE
Add default url for form configuration

### DIFF
--- a/demo/src/pages/FormConfiguration.tsx
+++ b/demo/src/pages/FormConfiguration.tsx
@@ -22,7 +22,7 @@ import { FormConfigurationProvider } from "@nrich/form-configuration-core";
 import { FormConfigurationInner } from "../components/FormConfigurationInner";
 
 const FormConfiguration = () => (
-  <FormConfigurationProvider loader="Loading..." url="/nrich/form/configuration">
+  <FormConfigurationProvider loader="Loading...">
     <FormConfigurationInner />
   </FormConfigurationProvider>
 );

--- a/libs/form-configuration/core/package.json
+++ b/libs/form-configuration/core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@nrich/form-configuration-core",
   "description": "Contains core utilities related to the nrich-form-configuration module",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "dependencies": {
     "zustand": "^4.0.0-rc.1",
     "yup": "^0.32.11"

--- a/libs/form-configuration/core/src/loader/fetch-form-configurations.ts
+++ b/libs/form-configuration/core/src/loader/fetch-form-configurations.ts
@@ -22,8 +22,9 @@ import { useFormConfigurationStore } from "../store/form-configuration-store";
 export const fetchFormConfigurations = async ({ url, requestOptionsResolver, additionalValidatorConverters }: FormConfigurationConfiguration): Promise<FormConfiguration[]> => {
   const formConfigurationValidationConverter = new FormConfigurationValidationConverter(additionalValidatorConverters);
   const additionalOptions = requestOptionsResolver?.() || {};
+  const finalUrl = url || "/nrich/form/configuration";
 
-  const response = await fetch(`${url}/fetch-all`, {
+  const response = await fetch(`${finalUrl}/fetch-all`, {
     method: "POST",
     ...additionalOptions,
   });


### PR DESCRIPTION
## Basic information

* nrich-demo-frontend version: 0.0.2
* Module: form-configuration


## Additional information

Currently, url is required parameter of `FormConfigurationProvider`. On backend, there is a default url (`/nrich/form/configuration`) which users will rarely change. To prevent every project to have to define this parameter, a default could be added.

## Description

### Summary

Added a default url that matches the one on backend.


### Related issue

Resolves #26 

## Types of changes

- Enhancement (non-breaking change which enhances existing functionality)

## Checklist

- [x] I have read the project's **CONTRIBUTING** document
- [x] I have checked my code with the project's static analysis tooling
- [x] I have formatted my code with the project's IDEA code-style configuration
- [x] I have checked my code for misspellings
- [x] I have organized my changes in easy-to-follow commits
- [x] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [ ] I have added tests to cover my changes
- [x] All new and existing tests pass.
