### PR TITLE
Added nullable as default yup validation to allow optional fields by default

### DIFF
--- a/libs/form-configuration/core/src/converter/FormConfigurationValidationConverter.ts
+++ b/libs/form-configuration/core/src/converter/FormConfigurationValidationConverter.ts
@@ -84,7 +84,7 @@ export class FormConfigurationValidationConverter {
         return;
       }
 
-      const validator = property.validatorList.reduce((previousValidator, validatorConfiguration) => this.applyConverter(validatorConfiguration, previousValidator), yupValidation());
+      const validator = property.validatorList.reduce((previousValidator, validatorConfiguration) => this.applyConverter(validatorConfiguration, previousValidator), yupValidation().nullable());
       const [propertyName, restOfPathList] = FormConfigurationValidationConverter.convertPath(property.path);
 
       if (restOfPathList.length > 0) {

--- a/libs/form-configuration/core/test/converter/FormConfigurationValidationConverter.test.ts
+++ b/libs/form-configuration/core/test/converter/FormConfigurationValidationConverter.test.ts
@@ -17,7 +17,7 @@
 
 import { FormConfigurationValidationConverter } from "../../src/converter/FormConfigurationValidationConverter";
 import {
-  createComplexValidationList, createCustomValidationList, createNestedValidationList, createSimpleValidationList, invalidValidationConfiguration,
+  createComplexValidationList, createCustomValidationList, createNestedValidationList, createSimpleNullableValidationList, createSimpleValidationList, invalidValidationConfiguration,
 } from "../testutil/form-configuration-generating-util";
 
 describe("@nrich/form-configuration-core/FormConfigurationValidationConverter", () => {
@@ -45,6 +45,7 @@ describe("@nrich/form-configuration-core/FormConfigurationValidationConverter", 
     // then
     expect(result).toBeDefined();
     expect(() => result.validateSync({ username: "" })).toThrowError("Username cannot be blank");
+    expect(() => result.validateSync({ username: null })).toThrowError("Username cannot be blank");
     expect(result.isValidSync({ username: "username" })).toBe(true);
   });
 
@@ -114,5 +115,18 @@ describe("@nrich/form-configuration-core/FormConfigurationValidationConverter", 
     expect(result).toBeDefined();
     expect(() => result.validateSync({ title: "other" })).toThrowError("Not in list: mr, mrs, miss");
     expect(result.isValidSync({ title: "mr" })).toBe(true);
+  });
+
+  it("should allow null if backend didn't define NotNull, NotBlank, NotEmpty", () => {
+    // given
+    const converter = new FormConfigurationValidationConverter();
+    const customValidationList = createSimpleNullableValidationList();
+
+    // when
+    const result = converter.convertFormConfigurationToYupSchema(customValidationList);
+
+    // then
+    expect(result).toBeDefined();
+    expect(result.isValidSync({ username: null })).toBe(true);
   });
 });

--- a/libs/form-configuration/core/test/testutil/form-configuration-generating-util.ts
+++ b/libs/form-configuration/core/test/testutil/form-configuration-generating-util.ts
@@ -62,6 +62,15 @@ export const createSimpleValidationList = () => [
   },
 ];
 
+export const createSimpleNullableValidationList = () => [
+  {
+    path: "username",
+    propertyType: "java.lang.String",
+    javascriptType: "string",
+    validatorList: [],
+  },
+];
+
 export const createComplexValidationList = () => [
   {
     path: "name",
@@ -167,7 +176,7 @@ export const createCustomValidationList = () => [
   },
 ];
 
-export const mockFormYupConfiguration: FormYupConfiguration = {
+export const mockFormYupConfiguration: FormYupConfiguration & FormConfiguration = {
   formId: "form-configuration.demo-request",
   yupSchema: yup.object().shape({
     username: yup.string().required(),
@@ -288,7 +297,7 @@ export const mockFormYupConfiguration: FormYupConfiguration = {
   ],
 };
 
-export const mockFormYupConfigurations: FormYupConfiguration[] = [
+export const mockFormYupConfigurations: (FormYupConfiguration & FormConfiguration)[] = [
   {
     formId: "form-configuration.demo-request",
     yupSchema: yup.object().shape({


### PR DESCRIPTION
## Basic information

* nrich-demo-frontend version: 0.0.3
* Module :nrich-form-configuration

## Additional information

yup version: 0.28.5

## Description

### Summary

When backend returns no validations, frontend didn't allow nullable values in fields returned. This PR fixes that problem


### Related issue

Resolves #28 

## Types of changes

- Bug fix (non-breaking change which fixes an issue)
- Enhancement (non-breaking change which enhances existing functionality)

## Checklist

- [x] I have read the project's **CONTRIBUTING** document
- [x] I have checked my code with the project's static analysis tooling
- [x] I have formatted my code with the project's IDEA code-style configuration
- [x] I have checked my code for misspellings
- [x] I have organized my changes in easy-to-follow commits
- [ ] My change requires a change to the documentation
- [ ] I have updated the documentation accordingly
- [x] I have added tests to cover my changes
- [x] All new and existing tests pass.
